### PR TITLE
Fix units of measurement in the example script

### DIFF
--- a/examples/ina228_simpletest.py
+++ b/examples/ina228_simpletest.py
@@ -21,7 +21,7 @@ while True:
     print(f"Current: {ina228.current*1000:.2f} mA")
     print(f"Bus Voltage: {ina228.bus_voltage:.2f} V")
     print(f"Shunt Voltage: {ina228.shunt_voltage*1000:.2f} mV")
-    print(f"Power: {ina228.power:.2f} mW")
+    print(f"Power: {ina228.power*1000:.2f} mW")
     print(f"Energy: {ina228.energy:.2f} J")
     print(f"Temperature: {ina228.die_temperature:.2f} °C")
     time.sleep(1)

--- a/examples/ina228_simpletest.py
+++ b/examples/ina228_simpletest.py
@@ -18,7 +18,7 @@ print(f"Samples averaged: {ina228.averaging_count}")
 
 while True:
     print("\nCurrent Measurements:")
-    print(f"Current: {ina228.current:.2f} mA")
+    print(f"Current: {ina228.current*1000:.2f} mA")
     print(f"Bus Voltage: {ina228.bus_voltage:.2f} V")
     print(f"Shunt Voltage: {ina228.shunt_voltage*1000:.2f} mV")
     print(f"Power: {ina228.power:.2f} mW")


### PR DESCRIPTION
The example script seems to intend to print out the current in milliamperes, but is actually printing it out in amperes as per the [API docs here](https://docs.circuitpython.org/projects/ina228/en/latest/api.html#adafruit_ina228.INA228.current). Similarly, it seems to intend to print power in milliwatts, but seems to actually print it in watts based on the api docs. This issue is also causing a loss in the precision of the readings due to the string formatting. I fixed it by just multiplying the API current and power outputs by 1000 before printing. Hope it helps :)